### PR TITLE
Full Polish translation

### DIFF
--- a/pl/LC_MESSAGES/messages.po
+++ b/pl/LC_MESSAGES/messages.po
@@ -1,20 +1,25 @@
 # Polish translations for pomodoro.
-# Copyright (C) 2018 ORGANIZATION
+# Copyright (C) 2018-2019 pomodoro-tracker.com
 # This file is distributed under the same license as the pomodoro project.
 # Jarosław Wiosna <EMAIL@ADDRESS>, 2018.
-# Roman Dąbal <dabalroman@gmail.com>, 2018.
+# Roman Dąbal <dabalroman@gmail.com>, 2019.
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: pomodoro 2.9.38\n"
-"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"Report-Msgid-Bugs-To: dabalroman@gmail.com\n"
 "POT-Creation-Date: 2019-01-21 13:09+0300\n"
-"PO-Revision-Date: 2018-12-26 22:18+0300\n"
+"PO-Revision-Date: 2019-02-02 00:19+0100\n"
 "Last-Translator: Roman Dąbal <dabalroman@gmail.com>\n"
 "Language: pl\n"
 "Language-Team: pl <LL@li.org>\n"
-"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && "
-"(n%100<10 || n%100>=20) ? 1 : 2)\n"
+"Plural-Forms: "nplurals = 3;"
+	"nmod = n%10;"
+	"aForm = (n == 1);"
+	"bForm = (nmod >= 2 && nmod <= 4);"
+	"bFormException = (n >= 5 && n <= 21);"
+	"/* cForm = (nmod >= 5 || nmod <= 1); */"
+	"plural = (aForm ? 0 : bForm && !bFormException ? 1 : 2)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -24,7 +29,7 @@ msgid "%1$s left"
 msgstr "Pozostało: %1$s"
 
 msgid "%1$s records were imported"
-msgstr "Importowane rekordy: %1$s"
+msgstr "Zaimportowano rekordy: %1$s"
 
 #, python-format
 msgid "%s here's your Daily report for %s"
@@ -49,19 +54,19 @@ msgid "Add Activity"
 msgstr "Dodaj aktywność"
 
 msgid "Add TODO"
-msgstr "Dodaj ZADANIE"
+msgstr "Dodaj zadanie"
 
 msgid "Add category"
 msgstr "Dodaj kategorię"
 
 msgid "Add more"
-msgstr "Dodaj więcej"
+msgstr "Dodaj kolejne"
 
 msgid "Add to TODO"
-msgstr "Dodaj do ZADANIA"
+msgstr "Dodaj zadanie"
 
 msgid "Alleviate anxiety linked to beginning"
-msgstr ""
+msgstr "Złagodzić uczucie niepokoju towarzyszące rozpoczynaniu nowego zadania"
 
 msgid "Application"
 msgstr "Aplikacja"
@@ -79,6 +84,8 @@ msgid ""
 "At the beginning of each day select the tasks you need to complete and "
 "put them on the TODO list above."
 msgstr ""
+"Na początku dnia wybierz zadania które musisz ukończyć "
+"i umieść je na liście zadań powyżej."
 
 msgid "At time"
 msgstr "Z rzędu"
@@ -90,13 +97,13 @@ msgid "Auto start breaks"
 msgstr "Automatycznie zaczynaj przerwy"
 
 msgid "Auto start pomodoros"
-msgstr "Automatycznie zaczynaj pomodoro"
+msgstr "Automatycznie zaczynaj kolejne Pomodoro"
 
 msgid "Bolster the determination to achieve your goals"
-msgstr ""
+msgstr "Podtrzymać determinację do osiągania wyznaczonych sobie celów"
 
 msgid "Boost motivation and keep it constant"
-msgstr ""
+msgstr "Poprawić motywację i utrzymywać ją"
 
 msgid "Break is over."
 msgstr "Przerwa zakończona."
@@ -114,16 +121,16 @@ msgid "Changes saved"
 msgstr "Zmiany zapisane"
 
 msgid "Clear DONE history once per day"
-msgstr "Wyczyść listę ZROBIONE raz dziennie"
+msgstr "Wyczyść listę wykonanych zadań raz dziennie"
 
 msgid "Clear the list"
 msgstr "Wyczyść listę"
 
 msgid "Click on a number to add more."
-msgstr "Naciśnij na numer by dodać więcej"
+msgstr "Naciśnij na numer by dodać więcej Pomodoro w ramach wybranego zadania."
 
 msgid "Click/tap to edit items."
-msgstr "Naciśnij by edytować"
+msgstr "Naciśnij zadanie aby je edytować."
 
 msgid "Close"
 msgstr "Zamknij"
@@ -132,7 +139,7 @@ msgid "Code"
 msgstr "Kod"
 
 msgid "Congratulations! You have finished all your tasks."
-msgstr "Gratulacje! Ukończono wszystkie zadania."
+msgstr "Gratulacje! Ukończyłeś/aś wszystkie zadania."
 
 msgid "Connect"
 msgstr "Połącz"
@@ -171,7 +178,7 @@ msgid "Disconnect"
 msgstr "Rozłącz"
 
 msgid "Don`t start next pomodoro if TODO is empty"
-msgstr "Nie zaczynaj kolejnego pomodoro jeśli list ZADANIA jest pusta"
+msgstr "Nie zaczynaj kolejnego pomodoro jeśli lista zadań jest pusta"
 
 msgid "Done"
 msgstr "Zrobione"
@@ -192,7 +199,7 @@ msgid "Enable Web Notifications"
 msgstr "Włącz powiadomienia systemowe"
 
 msgid "Enhance focus and concentration by cutting down on interruptions"
-msgstr ""
+msgstr "Poprawić skupienie i koncentrację poprzez ograniczenie przerw w pracy"
 
 msgid "Export the records as CSV"
 msgstr "Eksportuj dane do pliku CSV"
@@ -207,33 +214,39 @@ msgid "Feedback"
 msgstr "Opinie"
 
 msgid "Great work! TODO list is empty."
-msgstr "Dobra robota! Lista ZADANIA jest pusta."
+msgstr "Dobra robota! Lista zadania jest pusta."
 
 msgid "Hide notificaions"
 msgstr "Ukryj powiadomienia"
 
 msgid "If a task takes more than 5–7 Pomodoros, break it down"
 msgstr ""
+"Jeżeli zadanie zajmuje więcej niż 5 – 7 Pomodoro "
+"podziel je na mniejsze zadania"
 
 msgid ""
 "If it takes less than one Pomodoro, add it up, and combine  it with "
 "another task"
 msgstr ""
+"Jeżeli zadanie zajmuje mniej niż jedno Pomodoro "
+"połącz je z innym zadaniem"
 
 msgid "Import records from CSV"
 msgstr "Importuj dane z pliku CSV "
 
 msgid "Import was failed. Check your CSV and try again."
-msgstr "Próba importu zakończyła się błędem. Sprawdź plik CSV i spróbuj ponownie."
+msgstr ""
+"Próba importu zakończyła się błędem. "
+"Sprawdź plik CSV i spróbuj ponownie."
 
 msgid "Imported from External Sources"
 msgstr "Importowano z zewnętrznego źródła"
 
 msgid "Improve your work or study process"
-msgstr ""
+msgstr "Poprawić jakość Twojego procesu pracy lub nauki"
 
 msgid "Increase awareness of your decisions"
-msgstr ""
+msgstr "Zwiększyć świadomość o znaczeniu podejmowanych decyzji"
 
 msgid "Integration with Facebook"
 msgstr "Połącz z Facebook"
@@ -248,7 +261,7 @@ msgid "Integration with Telegram"
 msgstr "Połącz z Telegram"
 
 msgid "Integrations"
-msgstr "Połącz z zewnętrzymi usługami"
+msgstr "Integracja z innymi usługami"
 
 msgid "January"
 msgstr "Styczeń"
@@ -262,7 +275,8 @@ msgstr "Czerwiec"
 msgid ""
 "Keep on working, Pomodoro after Pomodoro, until the task at hand is "
 "finished. Every 4 Pomodoros take a longer break, (15–30 minutes)."
-msgstr ""
+msgstr "Kontynuuj pracę z Pomodoro do czasu ukończenia wszystkich zadań. "
+"Co 4 Pomodoro zrób sobie dłuższą przerwę (15 – 30 minut)."
 
 msgid "Language"
 msgstr "Język"
@@ -322,7 +336,7 @@ msgid "Mark as daily task"
 msgstr "Oznacz jako codzienne zadanie"
 
 msgid "Mark as done"
-msgstr "Oznacz jako zrobione"
+msgstr "Oznacz jako wykonane"
 
 msgid "May"
 msgstr "Maj"
@@ -340,7 +354,7 @@ msgid "Notifications"
 msgstr "Powiadomienia"
 
 msgid "Notify when there is one minute left"
-msgstr "Powiadom mnie gdy zostanie minuta do końca"
+msgstr "Powiadom mnie gdy zostanie minuta do końca Pomodoro"
 
 msgid "November"
 msgstr "Listopad"
@@ -352,7 +366,7 @@ msgid "Of those"
 msgstr "Z tych"
 
 msgid "Once a Pomodoro begins, it has to ring"
-msgstr ""
+msgstr "Pomodoro musi zadzwonić gdy się zaczyna"
 
 msgid "One minute left"
 msgstr "Pozostała jedna minuta"
@@ -404,6 +418,8 @@ msgstr "Brak rekordów"
 
 msgid "Refine the estimation process, both in qualitative and quantitative terms "
 msgstr ""
+"Doskonalić proces szacowania, "
+"zarówno w znaczeniu jakościowym jak i ilościowym"
 
 msgid "Register"
 msgstr "Zarejestruj"
@@ -424,13 +440,13 @@ msgid "STOP"
 msgstr "STOP"
 
 msgid "Schemes"
-msgstr "Schematy"
+msgstr "Schemat"
 
 msgid "Send Daily Reports"
 msgstr "Wysyłaj codzienne raporty"
 
 msgid "Send reports on email: "
-msgstr "Wysyłaj raporty na ten adres email:"
+msgstr "Wysyłaj raporty na ten adres email: "
 
 msgid "Send reports on telegram"
 msgstr "Wysyłaj raporty na Telegram"
@@ -460,10 +476,10 @@ msgid "Sort by"
 msgstr "Sortuj według"
 
 msgid "Start the Pomodoro timer"
-msgstr ""
+msgstr "Uruchom Pomodoro Timer"
 
 msgid "Start working:"
-msgstr "Zacznij pracę:"
+msgstr "Rozpocznij pracę:"
 
 msgid "Stats"
 msgstr "Statystyki"
@@ -472,6 +488,7 @@ msgid ""
 "Strengthen your resolve to keep on applying yourself in the face of "
 "complex situations"
 msgstr ""
+"Wzmocnić swoją determinację do stawania twarzą w twarz z trudnymi sytuacjami"
 
 msgid "Support the Project"
 msgstr "Wspomóż projekt"
@@ -480,22 +497,22 @@ msgid "Sync with Google Tasks"
 msgstr "Synchronizuj z Google Tasks"
 
 msgid "TODO"
-msgstr "ZADANIA"
+msgstr "zadania"
 
 msgid "TODO list is empty"
-msgstr "Lista ZADANIA jest pusta"
+msgstr "Lista zadań jest pusta"
 
 msgid "TODO list was updated."
-msgstr "Lista ZADANIA została zaktualizowana"
+msgstr "Lista zadań została zaktualizowana"
 
 msgid "Take a short break (3-5 minutes)"
-msgstr ""
+msgstr "Zrób sobie krótką przerwę (3 – 5 minut)"
 
 msgid "Thank you for the feedback! Your message is awaiting moderation."
 msgstr "Dziękujemy za Twoją opinie! Twoja wiadomość oczekuje na potwierdzenie."
 
 msgid "The Basics"
-msgstr "Podstawy"
+msgstr "W skrócie"
 
 msgid "The Goals"
 msgstr "Cele"
@@ -506,32 +523,49 @@ msgid ""
 "“the ticking clock”, especially when it involves a deadline, leads to "
 "ineffective work and study habits which in turn lead to procrastination."
 msgstr ""
+"Technika Pomodoro to metoda zarządzania czasem "
+"która może być zastosowana do ukończenia dowolnego zadania. "
+"Wiele osób widzi swojego przeciwnika w upływającym czasie. "
+"Niepokój powodowany przez „tykający zegar”, "
+"szczególnie gdy ogranicza nas deadline, "
+"prowadzi do zmniejszonej efektywności nauki i pracy. "
+"Powoduje to wyrabianie złych nawyków takich jak odkładanie spraw na później "
+"i pośpieszne załatwianie ich gdy zbliża się deadline."
 
 msgid ""
 "The Pomodoro Technique shouldn’t be used for activities you do in your "
 "free time. Enjoy free time!"
 msgstr ""
+"Technika Pomodoro nie powinna być stosowana dla czynności, "
+"które wykonujesz w Twoim wolnym czasie. Ciesz się nim!"
 
 msgid ""
 "The Pomodoro Technique will provide a simple tool/process for improving "
 "productivity (your own and that of your team members) which can do the "
 "following:"
 msgstr ""
+"Technika Pomodoro jest prostym narzędziem do poprawy wydajności "
+"(Twojej własnej I członków Twojego zespołu) które pomoże Ci:"
 
 msgid ""
 "The aim of the Pomodoro Technique is to use time as a valuable ally in "
 "accomplishing what we want to do in the way we want to do it, and to "
 "enable us to improve continually the way we work or study."
 msgstr ""
+"Celem metody Pomodoro jest użycie czasu "
+"jako wartościowego sprzymierzeńca w osiąganiu naszych celów, "
+"w taki sposób w jaki chcemy owe cele osiągać. "
+"Technika ta pozwala nieustannie usprawniać sposób "
+"w jaki uczymy się i pracujemy."
 
 msgid "The list is empty"
-msgstr "Lista jest pusta"
+msgstr "Ta lista jest pusta"
 
 msgid "The next Pomodoro will go better"
-msgstr ""
+msgstr "Następne Pomodoro będzie lepsze"
 
 msgid "The next pomodoro will go better!"
-msgstr ""
+msgstr "Następne Pomodoro będzie lepsze!"
 
 msgid "Theme"
 msgstr "Motyw"
@@ -570,7 +604,7 @@ msgid "Today"
 msgstr "Dzisiaj"
 
 msgid "Toggle fullscreen"
-msgstr "Przełącz pełny ekran"
+msgstr "Pełny ekran"
 
 msgid "Try to add some tasks use the form above"
 msgstr "Dodaj zadania w powyższym formularzu"
@@ -591,16 +625,16 @@ msgid "Volume"
 msgstr "Głośność"
 
 msgid "What is it?"
-msgstr "Co to jest?"
+msgstr "Czym jest technika Pomodoro?"
 
 msgid "Work days"
 msgstr "Dni robocze"
 
 msgid "Work history won`t be saved."
-msgstr "Historia pracy nie będzie zapisana."
+msgstr "Historia zadań nie będzie zapisana"
 
 msgid "Work until the Pomodoro rings"
-msgstr ""
+msgstr "Pracuj do czasu gdy Pomodoro zadzwoni"
 
 msgid "Write your ideas here"
 msgstr "Zapisz twoje pomysły tutaj"
@@ -609,10 +643,10 @@ msgid "Yesterday"
 msgstr "Wczoraj"
 
 msgid "You are not signed."
-msgstr "Nie jesteś zalogowany/zalogowana."
+msgstr "Nie jesteś zalogowany/a"
 
 msgid "You spent"
-msgstr "Spędzono"
+msgstr "Spędziłeś/aś"
 
 msgid "and"
 msgstr "i"
@@ -657,13 +691,13 @@ msgid "delays"
 msgstr "opóźnienia"
 
 msgid "delete"
-msgstr "usuń"
+msgstr "Usuń"
 
 msgid "focus"
 msgstr "skupienie"
 
 msgid "for all time"
-msgstr "na zawsze"
+msgstr "od początku istnienia tej aplikacji"
 
 msgid "hour"
 msgid_plural "hours"
@@ -672,19 +706,19 @@ msgstr[1] "godziny"
 msgstr[2] "godzin"
 
 msgid "in 10 seconds"
-msgstr "w ciągu 10 sekund"
+msgstr "po 10 sekundach"
 
 msgid "in 2 seconds"
-msgstr "w ciągu 2 sekund"
+msgstr "po 2 sekundach"
 
 msgid "in 3 seconds"
-msgstr "w ciągu 3 sekund"
+msgstr "po 3 sekundach"
 
 msgid "in 5 seconds"
-msgstr "w ciągu 5 sekund"
+msgstr "po 5 sekundach"
 
 msgid "in minutes"
-msgstr "w ciągu minut"
+msgstr "w minutach"
 
 msgid "in pomodoros"
 msgstr "w Pomodoro"
@@ -694,18 +728,18 @@ msgstr "Jasny"
 
 msgid "like"
 msgid_plural "likes"
-msgstr[0] "Polubienie"
-msgstr[1] "Polubienia"
-msgstr[2] "Polubień"
+msgstr[0] "polubienie"
+msgstr[1] "polubienia"
+msgstr[2] "polubień"
 
 msgid "median"
 msgstr "mediana"
 
 msgid "minute"
 msgid_plural "minutes"
-msgstr[0] "Minuta"
-msgstr[1] "Minuty"
-msgstr[2] "Minut"
+msgstr[0] "minuta"
+msgstr[1] "minuty"
+msgstr[2] "minut"
 
 msgid "month"
 msgid_plural "months"
@@ -720,7 +754,7 @@ msgid "no description"
 msgstr "brak opisu"
 
 msgid "number"
-msgstr "numer"
+msgstr "ilość"
 
 msgid "on"
 msgstr "na"
@@ -744,10 +778,10 @@ msgid "refresh"
 msgstr "odświeżać"
 
 msgid "registered users spend on completing pomodoros"
-msgstr "spędzili aktywni użytkownicy na Pomodoro"
+msgstr "aktywni użytkownicy spędzili korzystając z Pomodoro"
 
 msgid "registered users spend on completing pomodoros today."
-msgstr "spędzili dzisiaj aktywni użytkownicy na Pomodoro"
+msgstr "aktywni użytkownicy spędzili korzystając dzisiaj z Pomodoro."
 
 msgid "resume"
 msgstr "wznów"
@@ -770,7 +804,8 @@ msgstr "czas"
 msgid ""
 "to your telegram, type `/start` and enter a code from the bot to field "
 "bellow"
-msgstr ""
+msgstr "do Twojego Telegram'u, "
+"wpisz '/start' a następnie wpisz kod otrzymany od bota w pole poniżej"
 
 msgid "version"
 msgstr "wersja"


### PR DESCRIPTION
Commit includes translation of all previously empty strings and some updates.

Take a look at plural selection script syntax, I believe it should work fine. It has been tested as a regular JS.

I've found one translation related mistake in language selection drop-down, it says "Polskie". Correct version would be "Polski".